### PR TITLE
V2.2.1 message ids followup

### DIFF
--- a/src/Common/Client/Modules/AbstractFeatures.php
+++ b/src/Common/Client/Modules/AbstractFeatures.php
@@ -75,8 +75,12 @@ class AbstractFeatures
 
     protected function addMessageIds(ServerRequestInterface $serverRequestInterface, MessageIdInterface $request): ServerRequestInterface
     {
-        return $serverRequestInterface
-            ->withHeader('X-Request-ID', $request->getRequestId())
-            ->withHeader('X-Correlation-ID', $request->getCorrelationId());
+        if ($request->getRequestId() !== null) {
+            $serverRequestInterface = $serverRequestInterface->withHeader('X-Request-ID', $request->getRequestId());
+        }
+        if ($request->getCorrelationId() !== null) {
+            $serverRequestInterface = $serverRequestInterface->withHeader('X-Correlation-ID', $request->getCorrelationId());
+        }
+        return $serverRequestInterface;
     }
 }

--- a/tests/Common/Client/Modules/Versions/GetAvailableVersions/GetAvailableVersionsServiceTest.php
+++ b/tests/Common/Client/Modules/Versions/GetAvailableVersions/GetAvailableVersionsServiceTest.php
@@ -60,6 +60,7 @@ class GetAvailableVersionsServiceTest extends OcpiResponseTestCase
         $json = json_decode($payload, false, 512, JSON_THROW_ON_ERROR);
 
         $serverRequestInterface = $this->createMock(ServerRequestInterface::class);
+        $serverRequestInterface->method('withHeader')->willReturn($serverRequestInterface);
 
         $request = $this->createMock(GetAvailableVersionsRequest::class);
         $request->expects(TestCase::atLeastOnce())->method('getServerRequestInterface')->willReturn($serverRequestInterface);

--- a/tests/Versions/V2_1_1/Client/Versions/GetDetails/GetVersionDetailServiceTest.php
+++ b/tests/Versions/V2_1_1/Client/Versions/GetDetails/GetVersionDetailServiceTest.php
@@ -65,6 +65,7 @@ class GetVersionDetailServiceTest extends OcpiResponseTestCase
         $json = json_decode($payload, false, 512, JSON_THROW_ON_ERROR);
 
         $serverRequestInterface = $this->createMock(ServerRequestInterface::class);
+        $serverRequestInterface->method('withHeader')->willReturn($serverRequestInterface);
 
         $request = $this->createMock(GetVersionDetailRequest::class);
         $request->expects(TestCase::atLeastOnce())->method('getServerRequestInterface')->willReturn($serverRequestInterface);

--- a/tests/Versions/V2_2_1/Client/Versions/GetDetails/GetVersionDetailServiceTest.php
+++ b/tests/Versions/V2_2_1/Client/Versions/GetDetails/GetVersionDetailServiceTest.php
@@ -65,6 +65,7 @@ class GetVersionDetailServiceTest extends OcpiResponseTestCase
         $json = json_decode($payload, false, 512, JSON_THROW_ON_ERROR);
 
         $serverRequestInterface = $this->createMock(ServerRequestInterface::class);
+        $serverRequestInterface->method('withHeader')->willReturn($serverRequestInterface);
 
         $request = $this->createMock(GetVersionDetailRequest::class);
         $request->expects(TestCase::atLeastOnce())->method('getServerRequestInterface')->willReturn($serverRequestInterface);


### PR DESCRIPTION
Hello, thanks for the PR

Unfortunately some of the unit tests could not run after the change, because some methods were not mocked. I've fixed these. 
Also I have changed a bit the `addMessageIds` to prevent setting headers with empty values.

Could you merge these into your branch, then I'll merge your PR as a whole?